### PR TITLE
Add docker scan wrapper tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ To install other `ecocode` plugins, you can also :
 
 Then you can use C# test project repository to test the environment : see README.md of [C# test project](https://github.com/green-code-initiative/ecoCode-csharp-test-project)
 
+To analyze a .net codebase without having to install required components (i.e. .net SDK, JDK/JRE, etc.), you can use our [docker dotnetscan wrapper](./docker-dotnetscan/README.md).
+
 Finally, you can directly use a [all-in-one docker-compose](https://github.com/green-code-initiative/ecoCode-common/blob/main/doc/INSTALL.md#start-sonarqube-if-first-time)
 
 By default, `Dockerfile` use the official [Sonarqube LTS Community](https://hub.docker.com/_/sonarqube) image version.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
 
 networks:
   sonarnet:
+    name: sonarnet
     driver: bridge
 
 volumes:

--- a/docker-dotnetscan/Dockerfile
+++ b/docker-dotnetscan/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.0
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0
+
+RUN dotnet tool install --global dotnet-sonarscanner
+RUN set -ex; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends default-jre ; \
+  rm -rf /var/lib/apt/lists/*
+
+# Add global dotnet tools to PATH
+ENV PATH="$PATH:/root/.dotnet/tools"
+
+COPY ./docker_dotnetscan_entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /src
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["-h"]

--- a/docker-dotnetscan/README.md
+++ b/docker-dotnetscan/README.md
@@ -1,0 +1,53 @@
+.net analysis docker utility container
+===========
+
+Docker utility container for dotnet codebase analysis that can be use to scan .net code and upload result to a Sonarqube instance.
+This container is intended to be used as a standalone tool with the docker-compose configuration provided in this repo that starts a Sonarqube instance or an existing Sonarqube instance.
+With this tool, you don't need to install required components on your local environment. You just need to be able to launch docker container.
+
+## How to use
+
+### Build the image
+
+Build the docker image and tag it with a convenient name (for instance we named it `scanner`) :
+
+```sh
+docker build -t scanner .
+```
+
+### Analyze your code
+
+#### Prerequisites
+
+You need to have an up and running Sonarqube instance with :
+- the EcoCode CSharp plugin installed
+- Quality profile with EcoCode rules activated
+- An user token, global or project analysis token, cf. Sonarqube documentation : [Generating and using tokens](https://docs.sonarsource.com/sonarqube/latest/user-guide/user-account/generating-and-using-tokens/)
+
+The following samples commands are based on these assumptions :
+
+| Property      | Parameter | Value                   | Comments                                                                                                                   |
+| ------------- | --------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Project key   | -p        | `myDotNetProject`       | Project will be create automatically if you use a user token (i.e. `-l`) that is allowed to create one (i.e. admin rights) |
+| Auth token    | -l        | `squ_123456789`         | User token are `squ_XXXX`, projet analysis token are `sqp_XXXX`                                                            |
+| Sonarqube url | -u        | `http://localhost:9000` | Note : this is the default url if you omit to specify one with `-u` parameter                                              |
+
+Running a SonarQube analysis is straighforward. You just need to execute the following commands at **the root of your solution**.
+
+#### With a Sonarqube instance from our docker-compose
+
+```sh
+docker run --rm -it --mount type=bind,src="$(pwd)",target=/src --network sonarnet scanner -p myDotNetProject -u http://sonar:9000 -l squ_123456789
+```
+
+#### With an existing Sonarqube instance
+
+```sh
+docker run --rm -it --mount type=bind,src="$(pwd)",target=/src --network host scanner -p myDotNetProject -u http://localhost:9000 -l squ_123456789
+```
+
+For further available parameters, refer to Help
+
+```sh
+docker run --rm -it scanner -h
+```

--- a/docker-dotnetscan/docker_dotnetscan_entrypoint.sh
+++ b/docker-dotnetscan/docker_dotnetscan_entrypoint.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+get_help() {
+  # Display Help
+  echo "Run code analysis of dotnet codebase using Sonarqube."
+  echo
+  if [[ $(basename "$0") == "entrypoint.sh" ]]; then
+    get_help_docker
+  else
+    get_help_script
+  fi
+  echo
+}
+
+get_help_scanning_options() {
+  echo "Required:"
+  echo -e "\t-t|--token\tSonarqube global or project analysis auth token."
+  echo -e "or\t-l|--login\tSonarqube user auth token.\n"
+  echo "Optional:"
+  echo -e "\t-p|--project\tProject key (default: ecoCode-csharp-test-project)"
+  echo -e "\t-u|--url\tUrl to Sonarqube instance (default: http://localhost:9000)"
+  echo -e "\t-h|--help\tPrint this help\n"
+  echo "Arguments:"
+  echo -e "\tSpecify <build-commands> to dotnet, if needed (default: \"build\")"
+}
+
+get_help_script() {
+  echo "Usage: $(basename "$0") -t|-l|--token|-login <auth_token> [-p|--project <project_key>] [-u|--url <sonarqube_url>] [-h|--help] [-- [<build-commands>]]"
+  echo
+  echo -e "Options:\n--------"
+  get_help_scanning_options
+}
+
+get_help_docker() {
+  echo "Usage: docker run --rm -it <container-params> scanner <analysis-params>"
+  echo
+  echo -e "container-params:\n-----------------"
+  echo -e "\t--mount type=bind,src=\"<path_to_codebase>\",target=/src [--network <name>]"
+  echo "Required:"
+  echo -e "\t--mount\t\tVolume mounting options, specify <path_to_codebase> with the root path to codebase to analyze.\n"
+  echo "Optional:"
+  echo -e "\t--network\tSpecify docker network to use."
+  echo
+  echo -e "analysis-params:\n----------------"
+  echo -e "\t-t|-l|--token|-login <auth_token> [-p|--project <project_key>] [-u|--url <sonarqube_url>] [-h|--help] [-- [<build-commands>]]"
+  get_help_scanning_options
+}
+
+if [[ $# -lt 1 ]]; then
+  echo "Error missing argument. You should provide at least an auth token."
+  echo
+  get_help
+  exit
+fi
+
+# Process command line args
+while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
+  case $1 in
+  -h | --help)
+    get_help
+    exit
+    ;;
+  -p | --project)
+    shift
+    project=$1
+    ;;
+  -t | --token)
+    shift
+    auth_token=$1
+    ;;
+  -l | --login)
+    shift
+    auth_login=$1
+    ;;
+  -u | --url)
+    shift
+    url=$1
+    ;;
+  esac
+  shift
+done
+# Skip optional '--'
+if [[ "$1" == '--' ]]; then shift; fi
+# Get all remaining args
+CMD_ARGS=$@
+
+# Get passed args value or set to default value
+PROJECT_KEY=${project:=ecoCode-csharp-test-project}
+SONAR_HOST=${url:=http://localhost:9000}
+if [[ -z $CMD_ARGS ]]; then
+  DOTNET_ARGS="build"
+else
+  DOTNET_ARGS=$CMD_ARGS
+fi
+
+if [[ -n $auth_login ]]; then
+  SONAR_TOKEN_TYPE="sonar.login"
+  SONAR_TOKEN=$auth_login
+fi
+if [[ -n $auth_token ]]; then
+  SONAR_TOKEN_TYPE="sonar.token"
+  SONAR_TOKEN=$auth_token
+fi
+
+# Check mandatory args
+if [[ -z $SONAR_TOKEN ]]; then
+  echo "Auth token is empty. You have to provide one with -t option."
+  exit 1
+fi
+
+# Check requirements
+# ---
+# Sonar scanner installed ?
+if [ $(dotnet tool list --global | grep dotnet-sonarscanner | wc -l) -ne 1 ]; then
+  echo "'dotnet-sonarscanner' tool NOT installed : please, install it with command 'dotnet tool install --global dotnet-sonarscanner'"
+  exit 1
+fi
+# Java JDK or JRE installed ?
+if [ -z $(which java) ]; then
+  echo "Java JDK/JRE is required to process Sonarque analysis. Please installed one."
+  exit 1
+fi
+
+# Analyze code
+dotnet sonarscanner begin /k:"$PROJECT_KEY" /d:sonar.host.url="$SONAR_HOST" /d:$SONAR_TOKEN_TYPE="$SONAR_TOKEN" || exit 1
+dotnet $DOTNET_ARGS
+dotnet sonarscanner end /d:$SONAR_TOKEN_TYPE="$SONAR_TOKEN"


### PR DESCRIPTION
Add wrapper tool to scan codebase with a docker container.
We don't need anymore to install required .net framework locally.
Useful for quick testing purpose but could also be used as part of a CI/CD tool if we publish the docker image publicly.